### PR TITLE
Add toCSV support for arbitrary arrays

### DIFF
--- a/.mongorc.js
+++ b/.mongorc.js
@@ -32,7 +32,7 @@ function csvrow( arr ) {
 }
 function printcsv( arr ) { print( csvrow( arr ) ); }
 
-DBQuery.prototype.toCSV = DBCommandCursor.prototype.toCSV = toCSV;
+DBQuery.prototype.toCSV = DBCommandCursor.prototype.toCSV = Array.prototype.toCSV = toCSV;
 function toCSV( opts={} ) {
   const { columns = [], headers = true } = opts;
 


### PR DESCRIPTION
It can be handy in some more complex mongo queries to manipulate results from a mongo query further before wanting to export them. In those cases, it can be helpful to be able to call the `toCSV` method on arrays as well as mongo query objects.